### PR TITLE
jwt側に薄いラッパー関数を書く 

### DIFF
--- a/src/auth/jwt.go
+++ b/src/auth/jwt.go
@@ -68,7 +68,7 @@ func GetIdByToken(token JwtClaims) (int, error) {
 }
 
 func GetIdBySession(c *gin.Context) (int, error) {
-	token, err := VerifySession(c)
+	token, err := VerifyContext(c)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## 関連するIssue番号

close #162 

## 変更内容

auth/jwt.go

## 変更理由

使い勝手が悪いのでラッパーを書きました。