### PR TITLE
fix bug

### DIFF
--- a/src/controller/plan.go
+++ b/src/controller/plan.go
@@ -70,7 +70,7 @@ func (con *Controller) CreatePlan(c *gin.Context) {
 			AbortWithError(c, http.StatusUnauthorized, "Authorization Failed", err)
 			return
 		}
-		plan.CreatorUser = &domain.MaskedUser{
+		plan.CreatorUser = domain.MaskedUser{
 			ID: id,
 		}
 	}


### PR DESCRIPTION
- close #208 

```go
var a interface{}
a = &domain.MaskedUser{...}
```
のとき，aは参照の参照型になるんですね，はい。